### PR TITLE
Remove duplicate entry for LA Times

### DIFF
--- a/credible/credible.csv
+++ b/credible/credible.csv
@@ -4,7 +4,6 @@
 "chicagotribune.com",""
 "independent.co.uk",""
 "latimes.com",""
-"latimes.com",""
 "reuters.com",""
 "nature.com",""
 "newyorktimes.com",""

--- a/credible/credible.json
+++ b/credible/credible.json
@@ -4,7 +4,6 @@
 	{"url": "chicagotribune.com", "type": ""},
 	{"url": "independent.co.uk", "type": ""},
 	{"url": "latimes.com", "type": ""},
-	{"url": "latimes.com", "type": ""},
 	{"url": "reuters.com", "type": ""},
 	{"url": "nature.com", "type": ""},
 	{"url": "newyorktimes.com", "type": ""},


### PR DESCRIPTION
Thanks for all the work on this! While perusing the data, I noticed a duplicate entry for the LA Times. This minor PR removes the duplicate.